### PR TITLE
fix bug due to linspace float argument

### DIFF
--- a/det3d/datasets/kitti/eval.py
+++ b/det3d/datasets/kitti/eval.py
@@ -434,7 +434,9 @@ def do_coco_style_eval(
     min_overlaps = np.zeros([10, *overlap_ranges.shape[1:]])
     for i in range(overlap_ranges.shape[1]):
         for j in range(overlap_ranges.shape[2]):
-            min_overlaps[:, i, j] = np.linspace(*overlap_ranges[:, i, j])
+            # min_overlaps[:, i, j] = np.linspace(*overlap_ranges[:, i, j])
+            start, stop, num = overlap_ranges[:, i, j]
+            min_overlaps[:, i, j] = np.linspace(start, stop, int(num))
     mAP_bbox, mAP_bev, mAP_3d, mAP_aos = do_eval_v2(
         gt_annos,
         dt_annos,


### PR DESCRIPTION
When I tried to evaluate your model checkpoint on kitti dataset, I got the following error:
`TypeError: 'numpy.float64' object cannot be interpreted as an integer`
This issue also cropped up in Det3D https://github.com/poodarchu/Det3D/pull/33. This PR should fix the issue.